### PR TITLE
Add icons to navbar and style them accordingly

### DIFF
--- a/assets/less/app.less
+++ b/assets/less/app.less
@@ -8,6 +8,14 @@
 
 @import "_overrides";
 
+.navbar {
+  li a span {
+    position: relative;
+    top: 4px;
+    margin-top: -4px;
+  }
+}
+
 .panel-profile {
   .header {
     height: 100px;

--- a/assets/less/app.less
+++ b/assets/less/app.less
@@ -9,10 +9,15 @@
 @import "_overrides";
 
 .navbar {
-  li a span {
-    position: relative;
-    top: 4px;
-    margin-top: -4px;
+  li a {
+    [class^="mdi-"], [class*="mdi-"] {
+      position: relative;
+      top: 5px;
+      margin-top: -7px;
+    }
+    .navbar-icon-text {
+      .hidden-sm;
+    }
   }
 }
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -32,14 +32,30 @@
                     </ul>
                     <ul class="nav navbar-nav navbar-right">
                         {% if request.user.is_authenticated %}
-                            <li><a href="{% url 'users:profile' pk=request.user.pk %}">Profile</a></li>
                             <li>
-                                <a href="https://github.com/7Pros/circuit/blob/develop/MANUAL.md#welcome-to-the-circuit-user-manual">Help</a>
+                                <a href="{% url 'users:profile' pk=request.user.pk %}">
+                                    <span class="mdi-social-person"></span>
+                                    Profile
+                                </a>
                             </li>
-                            <li><a href="{% url 'users:logout' %}">Logout</a></li>
+                            <li>
+                                <a href="https://github.com/7Pros/circuit/blob/develop/MANUAL.md#welcome-to-the-circuit-user-manual">
+                                    <span class="mdi-action-help"></span>
+                                    Help
+                                </a>
+                            </li>
+                            <li>
+                                <a href="{% url 'users:logout' %}">
+                                    <span class="mdi-action-exit-to-app"></span>
+                                    Logout
+                                </a>
+                            </li>
                         {% else %}
                             <li>
-                                <a href="https://github.com/7Pros/circuit/blob/develop/MANUAL.md#welcome-to-the-circuit-user-manual">Help</a>
+                                <a href="https://github.com/7Pros/circuit/blob/develop/MANUAL.md#welcome-to-the-circuit-user-manual">
+                                    <span class="mdi-action-help"></span>
+                                    Help
+                                </a>
                             </li>
                             {% if request.get_full_path != '/users/signup/' %}
                                 <li><a href="{% url 'users:signup' %}">Sign up</a></li>

--- a/templates/base.html
+++ b/templates/base.html
@@ -35,26 +35,26 @@
                             <li>
                                 <a href="{% url 'users:profile' pk=request.user.pk %}">
                                     <span class="mdi-social-person"></span>
-                                    Profile
+                                    <span class="navbar-icon-text">Profile</span>
                                 </a>
                             </li>
                             <li>
                                 <a href="https://github.com/7Pros/circuit/blob/develop/MANUAL.md#welcome-to-the-circuit-user-manual">
                                     <span class="mdi-action-help"></span>
-                                    Help
+                                    <span class="navbar-icon-text">Help</span>
                                 </a>
                             </li>
                             <li>
                                 <a href="{% url 'users:logout' %}">
                                     <span class="mdi-action-exit-to-app"></span>
-                                    Logout
+                                    <span class="navbar-icon-text">Logout</span>
                                 </a>
                             </li>
                         {% else %}
                             <li>
                                 <a href="https://github.com/7Pros/circuit/blob/develop/MANUAL.md#welcome-to-the-circuit-user-manual">
                                     <span class="mdi-action-help"></span>
-                                    Help
+                                    <span class="navbar-icon-text">Help</span>
                                 </a>
                             </li>
                             {% if request.get_full_path != '/users/signup/' %}


### PR DESCRIPTION
Replaces #195 

This is essentially the same, but with cleaner code and styles in less not inline.
#195 was a bit hacky and the ripple effect wasn't full width and height, like now in my version.

![screenshot from 2015-07-08 12-29-12](https://cloud.githubusercontent.com/assets/872251/8568344/21bc3546-256d-11e5-87d4-6ead4dd0b7ec.png)

Thanks @juanecabellob for the initial idea and PR.
